### PR TITLE
Included fields allowDropoff and isFloatingBike to BikeRentalStation

### DIFF
--- a/src/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
+++ b/src/org/opentripplanner/routing/bike_rental/BikeRentalStation.java
@@ -41,6 +41,10 @@ public class BikeRentalStation implements Serializable {
 /*    @XmlAttribute
     @JsonSerialize*/
     public int spacesAvailable = Integer.MAX_VALUE;
+
+    public boolean allowDropoff = true;
+
+    public boolean isFloatingBike = false;
     
     /**
      * Whether this station is static (usually coming from OSM data) or a real-time source. If no real-time data, users should take


### PR DESCRIPTION
These fields are already available in OTP bike_rental endpoint were not included in the POJO.