### PR TITLE
ci: add JDK8 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - openjdk8


### PR DESCRIPTION
To add JDK 8 configuration to Travis CI. 